### PR TITLE
Recognize newest link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ To use it, upload the ```xExtension-Dilbert``` directory to the FreshRSS `./exte
 
 This extension supports both feed addresses:
 
-- the old one at http://feeds.feedburner.com/DilbertDailyStrip
-- and the new one at http://feed.dilbert.com/dilbert/daily_strip 
+- the oldest one at https://feeds.feedburner.com/DilbertDailyStrip
+- the newer one at http://feed.dilbert.com/dilbert/daily_strip 
+- and the newest one at https://dilbert.com/feed
 
 But this extension will ONLY work on new added feed items as it manipulates them while fetching new items.
 

--- a/xExtension-Dilbert/extension.php
+++ b/xExtension-Dilbert/extension.php
@@ -95,7 +95,7 @@ class DilbertExtension extends Minz_Extension
 
         $urlParts = explode('/', $entry->link());
         $date = $urlParts[count($urlParts)-1];
-        $url = 'http://dilbert.com/strip/' . $date;
+        $url = 'https://dilbert.com/strip/' . $date;
 
         libxml_use_internal_errors(true);
         $dom = new DOMDocument;

--- a/xExtension-Dilbert/extension.php
+++ b/xExtension-Dilbert/extension.php
@@ -72,11 +72,11 @@ class DilbertExtension extends Minz_Extension
 
         if (
             stripos($link, '://feedproxy.google.com/~r/DilbertDailyStrip') === false &&
-            stripos($link, '://feed.dilbert.com/~r/dilbert/daily_strip') === false
+            stripos($link, '://feed.dilbert.com/~r/dilbert/daily_strip') === false &&
+            stripos($link, '://dilbert.com/strip/') === false
         ) {
             return false;
         }
-
         return true;
     }
 


### PR DESCRIPTION
The [newest atom feed](https://dilbert.com/feed) links to another url which the extension didn't recognize and therefore didn't parse.

The query is now also performed using https instead of http which works fine.