### PR TITLE
Fix extension definition

### DIFF
--- a/xExtension-Dilbert/extension.php
+++ b/xExtension-Dilbert/extension.php
@@ -12,6 +12,20 @@
  */
 class DilbertExtension extends Minz_Extension
 {
+    public function install()
+    {
+        return true;
+    }
+
+    public function uninstall()
+    {
+        return true;
+    }
+
+    public function handleConfigureAction()
+    {
+    }
+
     /**
      * Initialize this extension
      */


### PR DESCRIPTION
Before, extension was missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extension have all mandatory method definitions.